### PR TITLE
avoid space character in nonce

### DIFF
--- a/scramsha1/scramsha1.go
+++ b/scramsha1/scramsha1.go
@@ -34,7 +34,7 @@ func generateNonce(length uint16, source io.Reader) ([]byte, error) {
 		}
 
 		for i := 0; i < n; i++ {
-			if nonceTemp[i] < 32 || nonceTemp[i] >= 127 || nonceTemp[i] == 44 {
+			if nonceTemp[i] <= 32 || nonceTemp[i] >= 127 || nonceTemp[i] == 44 {
 				continue
 			}
 			nonce[idx] = nonceTemp[i]


### PR DESCRIPTION
space characters are not allowed in the nonce according to
https://tools.ietf.org/html/rfc5802:

    printable       = %x21-2B / %x2D-7E